### PR TITLE
Adding delete support to HTTP transport support

### DIFF
--- a/scales/http/builder.py
+++ b/scales/http/builder.py
@@ -28,6 +28,13 @@ class _HttpIface(object):
     """
     pass
 
+  def Delete(self, url, **kwargs):
+    """Issue an HTTP DELETE to url.
+
+    kwargs aligns with arguments to requests, although timeout is ignored.
+    """
+    pass
+
 
 class Http(object):
   @staticmethod

--- a/scales/http/sink.py
+++ b/scales/http/sink.py
@@ -106,6 +106,8 @@ class HttpTransportSink(HttpTransportSinkBase):
       response = self._session.post(url, **kwargs)
     elif method == 'put':
       response = self._session.put(url, **kwargs)
+    elif method == 'delete':
+      response = self._session.delete(url, **kwargs)
     else:
       raise NotImplementedError()
     return response

--- a/scales/sink.py
+++ b/scales/sink.py
@@ -15,7 +15,10 @@ from collections import (deque, namedtuple)
 from weakref import WeakValueDictionary
 import time
 
-from gevent.coros import RLock
+try:
+  from gevent.coros import RLock
+except:
+  from gevent.lock import RLock
 
 from .async import AsyncResult
 from .constants import (ChannelState, SinkProperties, SinkRole)


### PR DESCRIPTION
A quick PR to add delete support for the HTTP transport. I could patch this in place for my own code, but thought others might benefit from the addition. 