### PR TITLE
Fix for broken ci tests due to thift 0.10.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
             'scales.thriftmux'],
   install_requires=[
       'gevent>=0.13.8',
-      'thrift>=0.5.0',
+      'thrift>=0.5.0,<=0.9.3',
       'kazoo>=1.3.1',
       'requests>=2.0.0']
 )


### PR DESCRIPTION
I see the latest travis-ci tests are failing. It appears to be due to the release of thrift 0.10.0, with some possibly incompatible changes/deprecations. This PR pins the thrift version betweeen 0.5.0 and 0.9.3. 

Test output before the change:
```
...No handlers could be found for logger "scales.loadbalancer.ApertureBalancerSink.[mock]"
.........................................E......
======================================================================
ERROR: testDeserialization (test.scales.thrift.test_serialization.ThriftSerializerTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jrichard/dev/python/scales/test/scales/thrift/test_serialization.py", line 21, in testDeserialization
    ret = s.DeserializeThriftCall(buf)
  File "/Users/jrichard/dev/python/scales/scales/thrift/serializer.py", line 104, in DeserializeThriftCall
    result.read(protocol)
  File "/Users/jrichard/dev/python/scales/test/scales/thrift/gen_py/hello/Hello.py", line 183, in read
    fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
AttributeError: 'TMemoryBuffer' object has no attribute 'trans'

----------------------------------------------------------------------
Ran 51 tests in 1.858s

FAILED (errors=1)
```

Test output after the change:
```
...No handlers could be found for logger "scales.loadbalancer.ApertureBalancerSink.[mock]"
................................................
----------------------------------------------------------------------
Ran 51 tests in 1.858s

OK
```