### PR TITLE
Completing HTTP methods

### DIFF
--- a/scales/http/builder.py
+++ b/scales/http/builder.py
@@ -35,6 +35,27 @@ class _HttpIface(object):
     """
     pass
 
+  def Patch(self, url, **kwargs):
+    """Issue an HTTP PATCH to url.
+
+    kwargs aligns with arguments to requests, although timeout is ignored.
+    """
+    pass
+
+  def Head(self, url, **kwargs):
+    """Issue an HTTP HEAD to url.
+
+    kwargs aligns with arguments to requests, although timeout is ignored.
+    """
+    pass
+
+  def Options(self, url, **kwargs):
+    """Issue an HTTP OPTIONS to url.
+
+    kwargs aligns with arguments to requests, although timeout is ignored.
+    """
+    pass
+
 
 class Http(object):
   @staticmethod

--- a/scales/http/sink.py
+++ b/scales/http/sink.py
@@ -108,6 +108,12 @@ class HttpTransportSink(HttpTransportSinkBase):
       response = self._session.put(url, **kwargs)
     elif method == 'delete':
       response = self._session.delete(url, **kwargs)
+    elif method == 'patch':
+      response = self._session.patch(url, **kwargs)
+    elif method == 'head':
+      response = self._session.head(url, **kwargs)
+    elif method == 'options':
+      response = self._session.options(url, **kwargs)
     else:
       raise NotImplementedError()
     return response


### PR DESCRIPTION
I figured while I was looking at this, I would go ahead and round out the request methods available from the python requests module into Scales. Feel free to take or decline this PR - just figured I could save you a little work if you'd like these included, 