### PR TITLE
Bump kazoo and gevent versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyo
+*.egg-info
 .vagrant
 Vagrantfile
 *.iml

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
             'scales.thrifthttp',
             'scales.thriftmux'],
   install_requires=[
-      'gevent>=0.13.8',
+      'gevent>=1.3.0',
       'thrift>=0.5.0',
-      'kazoo>=1.3.1',
+      'kazoo>=2.5.0',
       'requests>=2.0.0']
 )


### PR DESCRIPTION
`kazoo==2.4.0` is incompatible with `gevent==1.3.0`, (fixed here https://github.com/python-zk/kazoo/commit/257b58961f7ddd9db04d6efa070739a1b0404487)

The unit tests succeed with `thrift==0.10.0`, though I wasn't sure if fixing the tests should be another PR.